### PR TITLE
Remove validation on options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,12 +9,8 @@ request.debug = false;
 Arequest = (defaultOptions) => {
     let arequest;
 
-    Arequest.validateOptions(defaultOptions);
-
     arequest = async (url, options) => {
         return new Promise((resolve) => {
-            Arequest.validateOptions(options);
-
             options = _.assign({url: url}, options, defaultOptions);
 
             options = Arequest.mapOptions(options);
@@ -46,27 +42,6 @@ Arequest = (defaultOptions) => {
     };
 
     return arequest;
-};
-
-/**
- *
- */
-Arequest.validateOptions = (options) => {
-    let unknownOption;
-
-    if (!options) {
-        return;
-    }
-
-    unknownOption = _.first(_.difference(_.keys(options), ['method', 'data', 'headers', 'proxy', 'cookieJar', 'cookieJar2']));
-
-    if (unknownOption) {
-        throw new Error('Unknown option ("' + unknownOption + '").');
-    }
-
-    if (options.method && _.indexOf(['GET', 'POST', 'PUT', 'HEAD', 'DELETE'], options.method) === -1) {
-        throw new Error('Unknown option.method value ("' + options.method + '").');
-    }
 };
 
 /**


### PR DESCRIPTION
Request will validate the options in their library, there is no reason we need to revalidate them here.