### PR TITLE
Better error handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,8 @@ Arequest = (defaultOptions) => {
 
             request(options, (error, response) => {
                 if (error) {
-                    throw new Error(error);
+                    reject(error);
+                    return;
                 }
 
                 resolve({


### PR DESCRIPTION
Hey guys!

I replaced `new Error(error)` with rejecting the `Promise` instead. This way I was able to catch the error in a async/await function. Also the error from request is already an `Error` so I pass the error directly instead of wrapping it again in `Error`.

Let me know what you think and merge, if it’s a good idea. :)

Cheers