### PR TITLE
reject errors. don't throw

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ Arequest = (defaultOptions) => {
     Arequest.validateOptions(defaultOptions);
 
     arequest = async (url, options) => {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             Arequest.validateOptions(options);
 
             options = _.assign({url: url}, options, defaultOptions);
@@ -21,7 +21,7 @@ Arequest = (defaultOptions) => {
 
             request(options, (error, response) => {
                 if (error) {
-                    throw new Error(error);
+                    return reject(new Error(error.message));
                 }
 
                 resolve({


### PR DESCRIPTION
using reject allows caller to handle the error in a graceful way.  throwing the error was crashing my app.